### PR TITLE
fix: securely generate verification code

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"@swc/core": "1.3.6",
 		"@types/eslint": "8.4.6",
 		"@types/ioredis": "4.28.10",
-		"@types/node": "18.8.1",
+		"@types/node": "^18.8.4",
 		"@types/nodemailer": "6.4.6",
 		"@types/ws": "8.5.3",
 		"@typescript-eslint/eslint-plugin": "5.40.0",

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -2,6 +2,7 @@ import { verifyMsg } from '#lib/constants';
 import { informUserOfError } from '#lib/utils';
 import { ApplyOptions } from '@sapphire/decorators';
 import { Command } from '@sapphire/framework';
+import { randomBytes } from 'crypto';
 
 @ApplyOptions<Command.Options>({
 	description: 'Verify your Discord account using you VUW email address.'
@@ -109,7 +110,7 @@ export class UserCommand extends Command {
 		let discordLinked = await this.container.db.user.findFirst({ where: { id: authorId } });
 
 		// Generate verification code (6 char alpha numeric)
-		const code = Math.random().toString(36).split('').slice(2, 8).join('');
+		const code = randomBytes(3).toString('hex');
 
 		// create user if it doesn't already exist
 		if (!discordLinked) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,17 +1052,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.8.1":
-  version: 18.8.1
-  resolution: "@types/node@npm:18.8.1"
-  checksum: 6168dbdc42cbedff20fd16ed7c775038d6de52fe1458a9a3be07e39805c75d107f185908a8cdfe0b271f8f391a0c99fde27859975cf6b5a8fee385b3f5cfb42a
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^14.0.0":
   version: 14.18.26
   resolution: "@types/node@npm:14.18.26"
   checksum: c6ac3f9d4f6f77c0fa5ac17757779ad4d9835abfe3af5708b7552597cb5c7c1103e83499ccaf767a1cfa70040990bcf3f58761c547051dc8d5077f3c419091b1
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.8.4":
+  version: 18.8.4
+  resolution: "@types/node@npm:18.8.4"
+  checksum: c2b87f6b0b1f02b2ce61ca7cb93ea287119bda086a3f33e48da8f5e70c24ad7141cc3465946e0e36abb7eba70c7b320c7659842096e4aa573b3a8d557322c818
   languageName: node
   linkType: hard
 
@@ -1372,7 +1372,7 @@ __metadata:
     "@swc/core": 1.3.6
     "@types/eslint": 8.4.6
     "@types/ioredis": 4.28.10
-    "@types/node": 18.8.1
+    "@types/node": ^18.8.4
     "@types/nodemailer": 6.4.6
     "@types/ws": 8.5.3
     "@typescript-eslint/eslint-plugin": 5.40.0


### PR DESCRIPTION
Securely generate the verification code using `crypto` instead of `Math.random`.